### PR TITLE
Fix nginx proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ services:
       target: 80
     volumes:
     - ${PWD}/movim:/var/www/html:ro
+    - ${PWD}/nginx:/etc/nginx/conf.d/:ro
   postgresql:
     environment:
       POSTGRES_DB: movim

--- a/nginx/movim.conf
+++ b/nginx/movim.conf
@@ -8,11 +8,11 @@ server {
         index  index.html index.htm;
     }
 
-		location /movim {
-			alias /var/www/html/public/;
+    location /movim {
+      alias /var/www/html/public/;
       index  index.html index.htm index.php;
 
-			add_header Access-Control-Allow-Origin *;
+      add_header Access-Control-Allow-Origin *;
 
       location ~ \.php$ {
           fastcgi_pass   movim:9000;
@@ -22,18 +22,18 @@ server {
           include        fastcgi_params;
       }
 
-			location /movim/ws/ {
-				proxy_pass http://movim:8080/;
-				proxy_http_version 1.1;
-				proxy_set_header Upgrade $http_upgrade;
-				proxy_set_header Connection "Upgrade";
+      location /movim/ws/ {
+        proxy_pass http://movim:8080/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_redirect off;
-			}
-		}
+      }
+    }
 
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {

--- a/nginx/movim.conf
+++ b/nginx/movim.conf
@@ -1,0 +1,44 @@
+server {
+
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+		location /movim {
+			alias /var/www/html/public/;
+      index  index.html index.htm index.php;
+
+			add_header Access-Control-Allow-Origin *;
+
+      location ~ \.php$ {
+          fastcgi_pass   movim:9000;
+          fastcgi_index  index.php;
+          fastcgi_intercept_errors on;
+          fastcgi_param  SCRIPT_FILENAME $request_filename;
+          include        fastcgi_params;
+      }
+
+			location /movim/ws/ {
+				proxy_pass http://movim:8080/;
+				proxy_http_version 1.1;
+				proxy_set_header Upgrade $http_upgrade;
+				proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+			}
+		}
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+
+


### PR DESCRIPTION
`nginx` container in the example `docker-compose.yml` file is misconfigured and the application don't work correctly.

`movim` container already runs a php-fpm instance, forward the requests for PHP files to it.

websocket requests are forwarded to movim server runnning on port 8080 inside  `movim` container.