### PR TITLE
Added Support for Docker Secrets with PostgreSQL env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Example `stack.yml` for `movim`:
 services:
   movim:
     environment:
-      MOVIM_ADMIN: admin
-      MOVIM_PASSWORD: password
       MOVIM_DOMAIN: http://localhost
       MOVIM_PORT: 8080
       MOVIM_INTERFACE: 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ version: '3.7'
 ```
 Please note, you'll need to create the `nginx/default.conf` file yourself, to be mounted into the `nginx` container. You can find a good example configuration [here](https://gist.githubusercontent.com/kawaii/468f24135bc5cf817b922d8491276771/raw/bc0a881c5a505ffa677655f515502533d33b7174/movim.conf).
 
+You can also specify certain environment variables to be loaded from a file, by appending `_FILE` to the end. This is common practice for handling secrets in Docker; see [Docker Secrets](https://www.docker.com/blog/docker-secrets-management/) for more info. The only valid `_FILE` environment variables are the following
+* `$POSTGRES_DB_FILE`
+* `$POSTGRES_USER_FILE`
+* `$POSTGRES_PASSWORD_FILE`
+
 # Creating an Admin User
 
 After you've sucessfully logged in to your Movim Pod, run the following Docker Compose exec command;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,33 @@ if ! [ -e daemon.php -a -e public/index.php ]; then
 	echo >&2 "Complete! Movim ${MOVIM_VERSION} has been successfully copied to $PWD"
 fi
 
+if [ -z "${POSTGRES_PASSWORD:-}" ]; then
+    if [ -z "${POSTGRES_PASSWORD_FILE:-}" ]; then
+       echo Either POSTGRES_PASSWORD or POSTGRES_PASSWORD_FILE must be set 
+       exit 1
+    fi
+
+    POSTGRES_PASSWORD=$(<"$POSTGRES_PASSWORD_FILE")
+fi
+
+if [ -z "${POSTGRES_USER:-}" ]; then
+    if [ -z "${POSTGRES_USER_FILE:-}" ]; then
+       echo Either POSTGRES_USER or POSTGRES_USER_FILE must be set 
+       exit 1
+    fi
+
+    POSTGRES_USER=$(<"$POSTGRES_USER_FILE")
+fi
+
+if [ -z "${POSTGRES_DB:-}" ]; then
+    if [ -z "${POSTGRES_DB_FILE:-}" ]; then
+       echo Either POSTGRES_DB or POSTGRES_DB_FILE must be set 
+       exit 1
+    fi
+
+    POSTGRES_DB=$(<"$POSTGRES_DB_FILE")
+fi
+
 cat <<EOT > config/db.inc.php
 <?php
 \$conf = [


### PR DESCRIPTION
Many docker images have support for [docker secrets](https://www.docker.com/blog/docker-secrets-management/) via additional environment variables with the `_FILE` suffix. Specifying any of those environment variables sources the value from the file instead of from the environment itself. I added support for the `_FILE` counterparts to PostgreSQL environment variables supported by movim: 
* `$POSTGRES_DB_FILE`
* `$POSTGRES_USER_FILE`
* `$POSTGRES_PASSWORD_FILE`